### PR TITLE
fix(js-sdk): fix js-sdk package main file not found question

### DIFF
--- a/packages/js-sdk/package.json
+++ b/packages/js-sdk/package.json
@@ -2,7 +2,7 @@
   "name": "@ddn/js-sdk",
   "version": "0.1.16",
   "description": "DDN Node.js SDK",
-  "main": "dist/index.js",
+  "main": "lib/index.js",
   "unpkg": "build/index.browserify.js",
   "files": [
     "lib",


### PR DESCRIPTION
fix js-sdk package main file link error.And this package need to be published.